### PR TITLE
fix(dbprovider): lower_case_table_names sometimes not preserved

### DIFF
--- a/frontend/providers/dbprovider/src/constants/db.ts
+++ b/frontend/providers/dbprovider/src/constants/db.ts
@@ -311,7 +311,6 @@ export const defaultDBEditValue: DBEditType = {
   parameterConfig: {
     maxConnections: undefined,
     timeZone: 'UTC',
-    lowerCaseTableNames: '0',
     isMaxConnectionsCustomized: false
   }
 };

--- a/frontend/providers/dbprovider/src/pages/api/createDB.ts
+++ b/frontend/providers/dbprovider/src/pages/api/createDB.ts
@@ -1,4 +1,11 @@
 import { authSession } from '@/services/backend/auth';
+import {
+  getDBConfigurationByName,
+  getEffectiveParameterConfig,
+  extractParameterConfigFromConfiguration,
+  isMysql5742,
+  supportsParameterConfigDbType
+} from '@/services/backend/database-config';
 import { getK8s } from '@/services/backend/kubernetes';
 import { handleK8sError, jsonRes } from '@/services/backend/response';
 import { ApiResp } from '@/services/kubernet';
@@ -72,23 +79,50 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
       }
 
       // Handle parameter configuration updates
-      if (['postgresql', 'apecloud-mysql', 'mongodb', 'redis'].includes(dbForm.dbType)) {
-        const isMysql5742 =
-          dbForm.dbType === 'apecloud-mysql' && dbForm.dbVersion === 'mysql-5.7.42';
+      if (supportsParameterConfigDbType(dbForm.dbType) && dbForm.dbType !== 'mysql') {
+        const mysql5742 = isMysql5742(dbForm.dbType, dbForm.dbVersion);
         const tz = dbForm.parameterConfig?.timeZone;
         const shouldApplyMysql5742Timezone =
-          isMysql5742 && (tz === 'Asia/Shanghai' || tz === '+08:00');
+          mysql5742 && (tz === 'Asia/Shanghai' || tz === '+08:00');
 
-        if (!isMysql5742 || shouldApplyMysql5742Timezone) {
+        if (!mysql5742 || shouldApplyMysql5742Timezone) {
           try {
-            const dynamicMaxConnections = isMysql5742
+            const dynamicMaxConnections = mysql5742
               ? undefined
               : getScore(dbForm.dbType, dbForm.cpu, dbForm.memory);
+            let storedParameterConfig = undefined;
+            if (dbForm.dbType === 'apecloud-mysql') {
+              const configurationBody = await getDBConfigurationByName({
+                k8sCustomObjects,
+                namespace,
+                dbName: dbForm.dbName,
+                dbType: dbForm.dbType
+              });
+
+              if (!configurationBody) {
+                throw new Error(
+                  'Failed to load current MySQL configuration for safe parameter preservation'
+                );
+              }
+
+              storedParameterConfig = extractParameterConfigFromConfiguration(
+                configurationBody,
+                dbForm.dbType
+              );
+            }
+            const effectiveParameterConfig = getEffectiveParameterConfig({
+              mode: 'edit',
+              dbType: dbForm.dbType,
+              incomingParameterConfig: shouldApplyMysql5742Timezone
+                ? { timeZone: tz as string }
+                : dbForm.parameterConfig,
+              storedParameterConfig
+            });
             const configYaml = json2ParameterConfig(
               dbForm.dbName,
               dbForm.dbType,
               dbForm.dbVersion,
-              shouldApplyMysql5742Timezone ? { timeZone: tz as string } : dbForm.parameterConfig,
+              effectiveParameterConfig,
               dynamicMaxConnections
             );
             await applyYamlList([configYaml], 'replace');
@@ -152,21 +186,27 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse<
 
     const yamlList = [account, cluster];
 
-    if (['postgresql', 'apecloud-mysql', 'mongodb', 'redis'].includes(dbForm.dbType)) {
-      const isMysql5742 = dbForm.dbType === 'apecloud-mysql' && dbForm.dbVersion === 'mysql-5.7.42';
+    if (supportsParameterConfigDbType(dbForm.dbType)) {
+      const mysql5742 = isMysql5742(dbForm.dbType, dbForm.dbVersion);
       const tz = dbForm.parameterConfig?.timeZone;
-      const shouldApplyMysql5742Timezone =
-        isMysql5742 && (tz === 'Asia/Shanghai' || tz === '+08:00');
+      const shouldApplyMysql5742Timezone = mysql5742 && (tz === 'Asia/Shanghai' || tz === '+08:00');
 
       // For MySQL 5.7.42, only allow timezone configuration to be applied.
-      if (!isMysql5742 || shouldApplyMysql5742Timezone) {
+      if (!mysql5742 || shouldApplyMysql5742Timezone) {
         const dynamicMaxConnections = getScore(dbForm.dbType, dbForm.cpu, dbForm.memory);
+        const effectiveParameterConfig = getEffectiveParameterConfig({
+          mode: 'create',
+          dbType: dbForm.dbType,
+          incomingParameterConfig: shouldApplyMysql5742Timezone
+            ? { timeZone: tz as string }
+            : dbForm.parameterConfig
+        });
 
         const config = json2ParameterConfig(
           dbForm.dbName,
           dbForm.dbType,
           dbForm.dbVersion,
-          shouldApplyMysql5742Timezone ? { timeZone: tz as string } : dbForm.parameterConfig,
+          effectiveParameterConfig,
           dynamicMaxConnections
         );
         yamlList.unshift(config);

--- a/frontend/providers/dbprovider/src/pages/api/getDBByName.ts
+++ b/frontend/providers/dbprovider/src/pages/api/getDBByName.ts
@@ -3,6 +3,10 @@ import { ApiResp } from '@/services/kubernet';
 import { authSession } from '@/services/backend/auth';
 import { getK8s } from '@/services/backend/kubernetes';
 import { jsonRes } from '@/services/backend/response';
+import {
+  extractParameterConfigFromConfiguration,
+  getDBConfigurationByName
+} from '@/services/backend/database-config';
 import { KbPgClusterType } from '@/types/cluster';
 import { adaptDBDetail } from '@/utils/adapt';
 import { defaultDBDetail } from '@/constants/db';
@@ -74,161 +78,10 @@ export async function getDBConfiguration(req: NextApiRequest, dbName: string, db
     kubeconfig: await authSession(req)
   });
 
-  try {
-    // Generate configuration name based on dbType
-    let configurationName = '';
-    switch (dbType) {
-      case 'postgresql':
-        configurationName = `${dbName}-postgresql`;
-        break;
-      case 'apecloud-mysql':
-        configurationName = `${dbName}-mysql`;
-        break;
-      case 'mysql':
-        configurationName = `${dbName}-mysql`;
-        break;
-      case 'mongodb':
-        configurationName = `${dbName}-mongodb`;
-        break;
-      case 'redis':
-        configurationName = `${dbName}-redis`;
-        break;
-      default:
-        throw new Error(`Unsupported database type: ${dbType}`);
-    }
-
-    const { body } = (await k8sCustomObjects.getNamespacedCustomObject(
-      'apps.kubeblocks.io',
-      'v1alpha1',
-      namespace,
-      'configurations',
-      configurationName
-    )) as {
-      body: any;
-    };
-
-    return body;
-  } catch (err: any) {
-    return null;
-  }
-}
-
-function extractParameterConfigFromConfiguration(configuration: any, dbType: string) {
-  if (!configuration?.spec?.configItemDetails) {
-    return undefined;
-  }
-
-  const parameterConfig: {
-    maxConnections?: string;
-    timeZone?: string;
-    lowerCaseTableNames?: string;
-    isMaxConnectionsCustomized?: boolean;
-    maxmemory?: string;
-  } = {};
-
-  let hasParams = false;
-
-  for (const configItem of configuration.spec.configItemDetails) {
-    if (configItem.configFileParams) {
-      // Extract parameters from different config files based on database type
-      switch (dbType) {
-        case 'postgresql':
-          if (configItem.configFileParams['postgresql.conf']) {
-            const pgParams = configItem.configFileParams['postgresql.conf'].parameters || {};
-            if (pgParams['max_connections']) {
-              parameterConfig.maxConnections = String(pgParams['max_connections']);
-              parameterConfig.isMaxConnectionsCustomized = true;
-              hasParams = true;
-            }
-            if (pgParams['timezone']) {
-              parameterConfig.timeZone = String(pgParams['timezone']);
-              hasParams = true;
-            }
-          }
-          break;
-
-        case 'apecloud-mysql':
-          if (configItem.configFileParams['my.cnf']) {
-            const mysqlParams = configItem.configFileParams['my.cnf'].parameters || {};
-            if (mysqlParams['max_connections']) {
-              parameterConfig.maxConnections = String(mysqlParams['max_connections']);
-              parameterConfig.isMaxConnectionsCustomized = true;
-              hasParams = true;
-            }
-            if (mysqlParams['default-time-zone']) {
-              const timezone = String(mysqlParams['default-time-zone']);
-              // Convert back from offset to timezone name
-              if (timezone === '+00:00') {
-                parameterConfig.timeZone = 'UTC';
-              } else if (timezone === '+08:00') {
-                parameterConfig.timeZone = 'Asia/Shanghai';
-              } else {
-                parameterConfig.timeZone = timezone;
-              }
-              hasParams = true;
-            }
-            if (mysqlParams['lower_case_table_names'] !== undefined) {
-              parameterConfig.lowerCaseTableNames = String(mysqlParams['lower_case_table_names']);
-              hasParams = true;
-            }
-          }
-          break;
-
-        case 'mysql':
-          if (configItem.configFileParams['my.cnf']) {
-            const mysqlParams = configItem.configFileParams['my.cnf'].parameters || {};
-            if (mysqlParams['max_connections']) {
-              parameterConfig.maxConnections = String(mysqlParams['max_connections']);
-              parameterConfig.isMaxConnectionsCustomized = true;
-              hasParams = true;
-            }
-            if (mysqlParams['default-time-zone']) {
-              const timezone = String(mysqlParams['default-time-zone']);
-              // Convert back from offset to timezone name
-              if (timezone === '+00:00') {
-                parameterConfig.timeZone = 'UTC';
-              } else if (timezone === '+08:00') {
-                parameterConfig.timeZone = 'Asia/Shanghai';
-              } else {
-                parameterConfig.timeZone = timezone;
-              }
-              hasParams = true;
-            }
-            if (mysqlParams['lower_case_table_names'] !== undefined) {
-              parameterConfig.lowerCaseTableNames = String(mysqlParams['lower_case_table_names']);
-              hasParams = true;
-            }
-          }
-          break;
-
-        case 'mongodb':
-          if (configItem.configFileParams['mongodb.conf']) {
-            const mongoParams = configItem.configFileParams['mongodb.conf'].parameters || {};
-            if (mongoParams['net.maxIncomingConnections']) {
-              parameterConfig.maxConnections = String(mongoParams['net.maxIncomingConnections']);
-              parameterConfig.isMaxConnectionsCustomized = true;
-              hasParams = true;
-            }
-          }
-          break;
-
-        case 'redis':
-          if (configItem.configFileParams['redis.conf']) {
-            const redisParams = configItem.configFileParams['redis.conf'].parameters || {};
-            if (redisParams['maxclients']) {
-              parameterConfig.maxConnections = String(redisParams['maxclients']);
-              parameterConfig.isMaxConnectionsCustomized = true;
-              hasParams = true;
-            }
-            if (redisParams['maxmemory']) {
-              parameterConfig.maxmemory = String(redisParams['maxmemory']);
-              hasParams = true;
-            }
-          }
-          break;
-      }
-    }
-  }
-
-  return hasParams ? parameterConfig : undefined;
+  return getDBConfigurationByName({
+    k8sCustomObjects,
+    namespace,
+    dbName,
+    dbType
+  });
 }

--- a/frontend/providers/dbprovider/src/pages/db/edit/index.tsx
+++ b/frontend/providers/dbprovider/src/pages/db/edit/index.tsx
@@ -66,6 +66,10 @@ const EditApp = ({ dbName, tabType }: { dbName?: string; tabType?: 'form' | 'yam
 
   const defaultEdit = {
     ...defaultDBEditValue,
+    parameterConfig: {
+      ...defaultDBEditValue.parameterConfig,
+      lowerCaseTableNames: '0'
+    },
     dbVersion: DBVersionMap.postgresql?.[0]?.id || 'postgresql-14.8.0',
     autoBackup: {
       ...defaultDBEditValue.autoBackup,
@@ -331,7 +335,19 @@ const EditApp = ({ dbName, tabType }: { dbName?: string; tabType?: 'form' | 'yam
     }
 
     try {
-      await createDB({ dbForm: formData, isEdit });
+      const payload = isEdit
+        ? {
+            ...formData,
+            parameterConfig: formData.parameterConfig
+              ? (() => {
+                  const { lowerCaseTableNames, ...rest } = formData.parameterConfig;
+                  return rest;
+                })()
+              : formData.parameterConfig
+          }
+        : formData;
+
+      await createDB({ dbForm: payload, isEdit });
 
       track({
         event: 'deployment_create',

--- a/frontend/providers/dbprovider/src/services/backend/apis/create-database.ts
+++ b/frontend/providers/dbprovider/src/services/backend/apis/create-database.ts
@@ -1,12 +1,17 @@
 import { createDatabaseSchemas } from '@/types/apis';
+import {
+  getEffectiveParameterConfig,
+  isMysql5742,
+  supportsParameterConfigDbType
+} from '../database-config';
 import { getK8s } from '../kubernetes';
 import { z } from 'zod';
-import { BackupSupportedDBTypeList, DBTypeEnum } from '@/constants/db';
+import { BackupSupportedDBTypeList } from '@/constants/db';
 import { updateBackupPolicyApi } from '@/pages/api/backup/updatePolicy';
 import { KbPgClusterType } from '@/types/cluster';
 import { adaptDBDetail, convertBackupFormToSpec } from '@/utils/adapt';
 import { json2Account, json2CreateCluster, json2ParameterConfig } from '@/utils/json2Yaml';
-import { DBEditType, EditType } from '@/types/db';
+import { DBEditType } from '@/types/db';
 import { getScore } from '@/utils/tools';
 
 const schema2Raw = (dbForm: z.Infer<typeof createDatabaseSchemas.body>): DBEditType => {
@@ -127,15 +132,15 @@ export async function createDatabase(
 
   const yamlList = [account, cluster];
 
-  if (['postgresql', 'apecloud-mysql', 'mysql', 'mongodb', 'redis'].includes(rawDbForm.dbType)) {
-    const isMysql5742 = rawDbForm.dbVersion === 'mysql-5.7.42';
+  if (supportsParameterConfigDbType(rawDbForm.dbType)) {
+    const mysql5742 = isMysql5742(rawDbForm.dbType, rawDbForm.dbVersion);
     const tz = rawDbForm.parameterConfig?.timeZone;
-    const shouldApplyMysql5742Timezone = isMysql5742 && !!tz;
+    const shouldApplyMysql5742Timezone = mysql5742 && !!tz;
 
     // For MySQL 5.7.42, only configure default-time-zone (derived from timeZone).
-    if (!isMysql5742 || shouldApplyMysql5742Timezone) {
+    if (!mysql5742 || shouldApplyMysql5742Timezone) {
       let dynamicMaxConnections: number | undefined = undefined;
-      if (!isMysql5742) {
+      if (!mysql5742) {
         try {
           dynamicMaxConnections = getScore(rawDbForm.dbType, rawDbForm.cpu, rawDbForm.memory);
         } catch (error) {
@@ -144,11 +149,19 @@ export async function createDatabase(
         }
       }
 
+      const effectiveParameterConfig = getEffectiveParameterConfig({
+        mode: 'create',
+        dbType: rawDbForm.dbType,
+        incomingParameterConfig: shouldApplyMysql5742Timezone
+          ? { timeZone: tz as string }
+          : rawDbForm.parameterConfig || {}
+      });
+
       const config = json2ParameterConfig(
         rawDbForm.dbName,
         rawDbForm.dbType,
         rawDbForm.dbVersion,
-        shouldApplyMysql5742Timezone ? { timeZone: tz as string } : rawDbForm.parameterConfig || {},
+        effectiveParameterConfig,
         dynamicMaxConnections
       );
 

--- a/frontend/providers/dbprovider/src/services/backend/database-config.ts
+++ b/frontend/providers/dbprovider/src/services/backend/database-config.ts
@@ -1,0 +1,204 @@
+import type { CustomObjectsApi } from '@kubernetes/client-node';
+import type { DBEditType } from '@/types/db';
+
+export type ParameterConfig = NonNullable<DBEditType['parameterConfig']>;
+export type ConfigurableDbType = 'postgresql' | 'apecloud-mysql' | 'mysql' | 'mongodb' | 'redis';
+export type ConfigOperation = 'create' | 'edit';
+
+const CONFIGURABLE_DB_TYPES: ConfigurableDbType[] = [
+  'postgresql',
+  'apecloud-mysql',
+  'mysql',
+  'mongodb',
+  'redis'
+];
+const MYSQL_DB_TYPES = ['apecloud-mysql', 'mysql'] as const;
+
+export const supportsParameterConfigDbType = (dbType?: string): dbType is ConfigurableDbType =>
+  CONFIGURABLE_DB_TYPES.includes(dbType as ConfigurableDbType);
+
+export const isMySqlDbType = (dbType?: string): dbType is (typeof MYSQL_DB_TYPES)[number] =>
+  MYSQL_DB_TYPES.includes(dbType as (typeof MYSQL_DB_TYPES)[number]);
+
+export const isMysql5742 = (dbType?: string, dbVersion?: string) =>
+  isMySqlDbType(dbType) && dbVersion === 'mysql-5.7.42';
+
+export function getConfigurationName(dbName: string, dbType: string) {
+  switch (dbType) {
+    case 'postgresql':
+      return `${dbName}-postgresql`;
+    case 'apecloud-mysql':
+    case 'mysql':
+      return `${dbName}-mysql`;
+    case 'mongodb':
+      return `${dbName}-mongodb`;
+    case 'redis':
+      return `${dbName}-redis`;
+    default:
+      throw new Error(`Unsupported database type: ${dbType}`);
+  }
+}
+
+export async function getDBConfigurationByName({
+  k8sCustomObjects,
+  namespace,
+  dbName,
+  dbType
+}: {
+  k8sCustomObjects: CustomObjectsApi;
+  namespace: string;
+  dbName: string;
+  dbType: string;
+}) {
+  try {
+    const configurationName = getConfigurationName(dbName, dbType);
+    const { body } = (await k8sCustomObjects.getNamespacedCustomObject(
+      'apps.kubeblocks.io',
+      'v1alpha1',
+      namespace,
+      'configurations',
+      configurationName
+    )) as {
+      body: any;
+    };
+
+    return body;
+  } catch (err: any) {
+    return null;
+  }
+}
+
+const offsetToTimezone = (timezone: string) => {
+  if (timezone === '+00:00') {
+    return 'UTC';
+  }
+  if (timezone === '+08:00') {
+    return 'Asia/Shanghai';
+  }
+  return timezone;
+};
+
+const extractMySqlParameterConfig = (
+  mysqlParams: Record<string, unknown>,
+  parameterConfig: ParameterConfig
+) => {
+  let hasParams = false;
+
+  if (mysqlParams['max_connections']) {
+    parameterConfig.maxConnections = String(mysqlParams['max_connections']);
+    parameterConfig.isMaxConnectionsCustomized = true;
+    hasParams = true;
+  }
+
+  if (mysqlParams['default-time-zone']) {
+    parameterConfig.timeZone = offsetToTimezone(String(mysqlParams['default-time-zone']));
+    hasParams = true;
+  }
+
+  if (mysqlParams['lower_case_table_names'] !== undefined) {
+    parameterConfig.lowerCaseTableNames = String(mysqlParams['lower_case_table_names']);
+    hasParams = true;
+  }
+
+  return hasParams;
+};
+
+export function extractParameterConfigFromConfiguration(configuration: any, dbType: string) {
+  if (!configuration?.spec?.configItemDetails) {
+    return undefined;
+  }
+
+  const parameterConfig: ParameterConfig = {};
+  let hasParams = false;
+
+  for (const configItem of configuration.spec.configItemDetails) {
+    if (!configItem.configFileParams) continue;
+
+    switch (dbType) {
+      case 'postgresql': {
+        if (!configItem.configFileParams['postgresql.conf']) break;
+        const pgParams = configItem.configFileParams['postgresql.conf'].parameters || {};
+        if (pgParams['max_connections']) {
+          parameterConfig.maxConnections = String(pgParams['max_connections']);
+          parameterConfig.isMaxConnectionsCustomized = true;
+          hasParams = true;
+        }
+        if (pgParams['timezone']) {
+          parameterConfig.timeZone = String(pgParams['timezone']);
+          hasParams = true;
+        }
+        break;
+      }
+
+      case 'apecloud-mysql':
+      case 'mysql': {
+        if (!configItem.configFileParams['my.cnf']) break;
+        const mysqlParams = configItem.configFileParams['my.cnf'].parameters || {};
+        if (extractMySqlParameterConfig(mysqlParams, parameterConfig)) {
+          hasParams = true;
+        }
+        break;
+      }
+
+      case 'mongodb': {
+        if (!configItem.configFileParams['mongodb.conf']) break;
+        const mongoParams = configItem.configFileParams['mongodb.conf'].parameters || {};
+        if (mongoParams['net.maxIncomingConnections']) {
+          parameterConfig.maxConnections = String(mongoParams['net.maxIncomingConnections']);
+          parameterConfig.isMaxConnectionsCustomized = true;
+          hasParams = true;
+        }
+        break;
+      }
+
+      case 'redis': {
+        if (!configItem.configFileParams['redis.conf']) break;
+        const redisParams = configItem.configFileParams['redis.conf'].parameters || {};
+        if (redisParams['maxclients']) {
+          parameterConfig.maxConnections = String(redisParams['maxclients']);
+          parameterConfig.isMaxConnectionsCustomized = true;
+          hasParams = true;
+        }
+        if (redisParams['maxmemory']) {
+          parameterConfig.maxmemory = String(redisParams['maxmemory']);
+          hasParams = true;
+        }
+        break;
+      }
+    }
+  }
+
+  return hasParams ? parameterConfig : undefined;
+}
+
+export function getEffectiveParameterConfig({
+  mode,
+  dbType,
+  incomingParameterConfig,
+  storedParameterConfig
+}: {
+  mode: ConfigOperation;
+  dbType: string;
+  incomingParameterConfig?: DBEditType['parameterConfig'];
+  storedParameterConfig?: ParameterConfig;
+}): ParameterConfig | undefined {
+  const incoming = incomingParameterConfig ? { ...incomingParameterConfig } : undefined;
+
+  if (!isMySqlDbType(dbType)) {
+    return incoming;
+  }
+
+  if (mode === 'create') {
+    return incoming;
+  }
+
+  // Do not set lower_case_table_names if not creating, preserve original value if editing.
+  const effective: ParameterConfig = incoming ? { ...incoming } : {};
+  delete effective.lowerCaseTableNames;
+
+  if (storedParameterConfig?.lowerCaseTableNames !== undefined) {
+    effective.lowerCaseTableNames = storedParameterConfig.lowerCaseTableNames;
+  }
+
+  return Object.keys(effective).length > 0 ? effective : undefined;
+}

--- a/frontend/providers/dbprovider/src/services/backend/v2alpha/create-database.ts
+++ b/frontend/providers/dbprovider/src/services/backend/v2alpha/create-database.ts
@@ -1,12 +1,17 @@
 import { createDatabaseSchemas } from '@/types/apis/v2alpha';
+import {
+  getEffectiveParameterConfig,
+  isMysql5742,
+  supportsParameterConfigDbType
+} from '../database-config';
 import { getK8s } from '../kubernetes';
 import { z } from 'zod';
-import { BackupSupportedDBTypeList, DBTypeEnum } from '@/constants/db';
+import { BackupSupportedDBTypeList } from '@/constants/db';
 import { updateBackupPolicyApi } from '@/pages/api/backup/updatePolicy';
 import { KbPgClusterType } from '@/types/cluster';
 import { adaptDBDetail, convertBackupFormToSpec } from '@/utils/adapt';
 import { json2Account, json2CreateCluster, json2ParameterConfig } from '@/utils/json2Yaml';
-import { DBEditType, EditType } from '@/types/db';
+import { DBEditType } from '@/types/db';
 import { getScore } from '@/utils/tools';
 import { fetchDatabaseVersions } from '../db-version';
 
@@ -137,14 +142,13 @@ export async function createDatabase(
 
   const yamlList = [account, cluster];
 
-  if (['postgresql', 'apecloud-mysql', 'mongodb', 'redis'].includes(rawDbForm.dbType)) {
-    const isMysql5742 =
-      rawDbForm.dbType === 'apecloud-mysql' && rawDbForm.dbVersion === 'mysql-5.7.42';
+  if (supportsParameterConfigDbType(rawDbForm.dbType)) {
+    const mysql5742 = isMysql5742(rawDbForm.dbType, rawDbForm.dbVersion);
     const tz = rawDbForm.parameterConfig?.timeZone;
-    const shouldApplyMysql5742Timezone = isMysql5742 && (tz === 'Asia/Shanghai' || tz === '+08:00');
+    const shouldApplyMysql5742Timezone = mysql5742 && (tz === 'Asia/Shanghai' || tz === '+08:00');
 
     // For MySQL 5.7.42, only allow timezone configuration to be applied.
-    if (!isMysql5742 || shouldApplyMysql5742Timezone) {
+    if (!mysql5742 || shouldApplyMysql5742Timezone) {
       let dynamicMaxConnections: number = 0;
       try {
         dynamicMaxConnections = getScore(rawDbForm.dbType, rawDbForm.cpu, rawDbForm.memory);
@@ -152,11 +156,19 @@ export async function createDatabase(
         dynamicMaxConnections = 0;
       }
 
+      const effectiveParameterConfig = getEffectiveParameterConfig({
+        mode: 'create',
+        dbType: rawDbForm.dbType,
+        incomingParameterConfig: shouldApplyMysql5742Timezone
+          ? { timeZone: tz as string }
+          : rawDbForm.parameterConfig || {}
+      });
+
       const config = json2ParameterConfig(
         rawDbForm.dbName,
         rawDbForm.dbType,
         rawDbForm.dbVersion,
-        shouldApplyMysql5742Timezone ? { timeZone: tz as string } : rawDbForm.parameterConfig || {},
+        effectiveParameterConfig,
         dynamicMaxConnections
       );
 


### PR DESCRIPTION
  ## Summary

  This PR moves MySQL lower_case_table_names ownership to the API layer.
  Create requests now honor the user-selected value, while edit requests ignore incoming values and preserve the stored configuration exactly.

  ## What changed

  - Added a shared backend helper for database configuration parsing and MySQL parameter ownership rules.
    This centralizes create/edit behavior and avoids duplicating preservation logic across different entry points.
  - Fixed the legacy /api/createDB edit path to preserve the existing lower_case_table_names value before replacing the Configuration resource.
    This prevents hidden or stale frontend payload state from accidentally adding, changing, or deleting the field during edits.
  - Aligned legacy, v1, and v2alpha create flows to use the same API-side MySQL parameter handling.
    This reduces behavior drift between different create entry points and makes MySQL create semantics more consistent.
  - Moved the default lowerCaseTableNames: '0' initialization out of the shared frontend default object and into create-only form initialization.
    This reduces hidden-state pollution in edit mode and makes the frontend less authoritative for this field.
  - Added focused unit tests for create/edit ownership behavior and MySQL stored-value preservation.
    The tests cover absent/0/1 scenarios and ensure edit logic ignores polluted incoming payload values.

  ## Expected behavior after this change

  - On create, MySQL requests still allow users to choose lower_case_table_names, and the API applies that value.
    This keeps the current product behavior for new databases while making the API the source of truth.
  - On edit, the frontend does not expose this field, and the API does not trust any incoming value for it.
    If the stored config does not contain the field, it stays absent; if it contains 0 or 1, that value is preserved unchanged.