### PR TITLE
[codex] fix password workspace init failure

### DIFF
--- a/frontend/desktop/src/pages/api/auth/password/index.ts
+++ b/frontend/desktop/src/pages/api/auth/password/index.ts
@@ -16,7 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (!strongPassword(password)) {
       return jsonRes(res, {
         message:
-          'Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one number and one special character',
+          'Password must be at least 8 characters long and contain at least one non-whitespace character',
         code: 400
       });
     }
@@ -47,14 +47,32 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     // Auto init region for new users so callers can directly use regionToken API
     if (data.needInit && data.user) {
       try {
-        await initRegionToken({
+        const regionData = await initRegionToken({
           userUid: data.user.userUid,
           userId: data.user.userId,
           regionUid: getRegionUid(),
           workspaceName: 'My Workspace'
         });
+        if (!regionData) {
+          return jsonRes(res, {
+            data: {
+              token: data.token,
+              needInit: true
+            },
+            code: 409,
+            message: 'Failed to init workspace'
+          });
+        }
       } catch (e) {
         console.error('Auto init region failed:', e);
+        return jsonRes(res, {
+          data: {
+            token: data.token,
+            needInit: true
+          },
+          code: 409,
+          message: 'Failed to init workspace'
+        });
       }
     }
 


### PR DESCRIPTION
## Summary
- return an explicit 409 when password login cannot initialize the user's workspace
- preserve the global token with `needInit: true` on init failure instead of reporting a false `needInit: false`
- align the password validation message with the actual `strongPassword` rule

## Root cause
The password auth endpoint called `initRegionToken()` for new users but ignored both `null` results and caught errors. That let the endpoint return `200` with `needInit: false` even when the workspace was still uninitialized, causing the follow-up `/api/auth/regionToken` call to fail with `workspace is not inited`.

## Validation
- `pnpm dlx prettier@2.8.8 --check desktop/src/pages/api/auth/password/index.ts`
- `git diff --check`
- `pnpm exec lint-staged --debug` using the repo-pinned `lint-staged@15.2.9`

## Notes
- `pnpm --dir desktop lint` is currently blocked before code linting because `desktop/next.config.js` cannot resolve `next-pwa/cache` in this local environment.
- `pnpm --dir desktop exec tsc --noEmit --pretty false` is currently blocked before code checking because `@types/jest` is missing in this local environment.
- The raw husky hook uses `npx lint-staged`, which fetched `lint-staged@17` and failed on the repo's Node 20.4.0 runtime; the equivalent repo-pinned lint-staged check passed.
