### PR TITLE
feat(auth): enrich session data and fix analytics event order

### DIFF
--- a/frontend/desktop/src/__tests__/unit/utils/sessionConfig.test.ts
+++ b/frontend/desktop/src/__tests__/unit/utils/sessionConfig.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/api/auth', () => ({
+  UserInfo: vi.fn(),
+  getPlanInfo: vi.fn()
+}));
+
+vi.mock('jwt-decode', () => ({
+  jwtDecode: vi.fn()
+}));
+
+const mockSetToken = vi.fn();
+const mockSetSession = vi.fn();
+const mockSetHasEverLoggedIn = vi.fn();
+
+vi.mock('@/stores/session', () => ({
+  default: {
+    getState: vi.fn(() => ({
+      setToken: mockSetToken,
+      setSession: mockSetSession,
+      setHasEverLoggedIn: mockSetHasEverLoggedIn
+    }))
+  }
+}));
+
+import { UserInfo, getPlanInfo } from '@/api/auth';
+import { jwtDecode } from 'jwt-decode';
+import { sessionConfig } from '@/utils/sessionConfig';
+
+describe('sessionConfig', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(jwtDecode).mockReturnValue({
+      userCrName: 'k8s-user',
+      workspaceId: 'workspace-id',
+      workspaceUid: 'workspace-uid',
+      userCrUid: 'user-cr-uid',
+      userId: 'user-id',
+      userUid: 'user-uid'
+    } as any);
+
+    vi.mocked(UserInfo).mockResolvedValue({
+      data: {
+        info: {
+          nickname: '  display-name  ',
+          avatarUri: 'avatar-url',
+          userRestrictedLevel: 1,
+          realName: 'Real Name',
+          enterpriseRealName: 'Enterprise Name',
+          oauthProvider: [
+            {
+              providerType: 'EMAIL',
+              providerId: ' user@example.com '
+            }
+          ]
+        }
+      }
+    } as any);
+
+    vi.mocked(getPlanInfo).mockResolvedValue({
+      data: {
+        subscription: { planName: 'pro' }
+      }
+    } as any);
+  });
+
+  it('persists username and email into session for downstream analytics variables', async () => {
+    await sessionConfig({
+      token: 'region-token',
+      kubeconfig: 'kube-config',
+      appToken: 'app-token'
+    });
+
+    expect(mockSetToken).toHaveBeenCalledWith('region-token');
+    expect(mockSetSession).toHaveBeenCalledWith({
+      token: 'app-token',
+      subscription: { planName: 'pro' },
+      user: {
+        userRestrictedLevel: 1,
+        realName: 'Real Name',
+        enterpriseRealName: 'Enterprise Name',
+        k8s_username: 'k8s-user',
+        username: 'display-name',
+        email: 'user@example.com',
+        name: '  display-name  ',
+        avatar: 'avatar-url',
+        nsid: 'workspace-id',
+        ns_uid: 'workspace-uid',
+        userCrUid: 'user-cr-uid',
+        userId: 'user-id',
+        userUid: 'user-uid'
+      },
+      kubeconfig: 'kube-config'
+    });
+    expect(mockSetHasEverLoggedIn).toHaveBeenCalledWith(true);
+  });
+});

--- a/frontend/desktop/src/components/v2/EmailCheckForm.tsx
+++ b/frontend/desktop/src/components/v2/EmailCheckForm.tsx
@@ -77,11 +77,11 @@ export function EmailCheckForm({ isModal = false, onBack }: EmailCheckFormProps)
           const initResult = await autoInitRegionToken();
 
           if (initResult?.data) {
+            await sessionConfig(initResult.data);
             gtmLoginSuccess({
               user_type: 'new',
               method: 'email'
             });
-            await sessionConfig(initResult.data);
             const { setInitGuide } = useGuideModalStore.getState();
             setInitGuide(true);
             window.location.href = postLoginRedirect;
@@ -97,11 +97,11 @@ export function EmailCheckForm({ isModal = false, onBack }: EmailCheckFormProps)
       } else {
         const regionTokenRes = await getRegionToken();
         if (regionTokenRes?.data) {
+          await sessionConfig(regionTokenRes.data);
           gtmLoginSuccess({
             user_type: 'existing',
             method: 'email'
           });
-          await sessionConfig(regionTokenRes.data);
           window.location.href = postLoginRedirect;
         }
       }

--- a/frontend/desktop/src/components/v2/PhoneCheckForm.tsx
+++ b/frontend/desktop/src/components/v2/PhoneCheckForm.tsx
@@ -79,11 +79,11 @@ export function PhoneCheckForm({ isModal = false, onBack }: PhoneCheckFormProps)
           const initResult = await autoInitRegionToken();
 
           if (initResult?.data) {
+            await sessionConfig(initResult.data);
             gtmLoginSuccess({
               user_type: 'new',
               method: 'phone'
             });
-            await sessionConfig(initResult.data);
             const { setInitGuide } = useGuideModalStore.getState();
             setInitGuide(true);
             window.location.href = postLoginRedirect;
@@ -99,11 +99,11 @@ export function PhoneCheckForm({ isModal = false, onBack }: PhoneCheckFormProps)
       } else {
         const regionTokenRes = await getRegionToken();
         if (regionTokenRes?.data) {
+          await sessionConfig(regionTokenRes.data);
           gtmLoginSuccess({
             user_type: 'existing',
             method: 'phone'
           });
-          await sessionConfig(regionTokenRes.data);
           window.location.href = postLoginRedirect;
         }
       }

--- a/frontend/desktop/src/pages/api/auth/oauth/oauth2/index.ts
+++ b/frontend/desktop/src/pages/api/auth/oauth/oauth2/index.ts
@@ -64,6 +64,14 @@ export default ErrorHandler(async function handler(req: NextApiRequest, res: Nex
 
   // If name_path and user_name exist in attributes, combine them
   const attributes = (result as any)?.attributes;
+  const emailCandidate =
+    (result as any)?.email ||
+    attributes?.email ||
+    attributes?.mail ||
+    result?.preferred_username ||
+    '';
+  const email =
+    typeof emailCandidate === 'string' && emailCandidate.includes('@') ? emailCandidate : undefined;
   const name =
     attributes?.name_path && attributes?.user_name
       ? `${attributes.name_path} ${attributes.user_name}`
@@ -76,6 +84,7 @@ export default ErrorHandler(async function handler(req: NextApiRequest, res: Nex
     providerId: id + '',
     avatar_url,
     name,
+    email,
     semData,
     adClickData
   });

--- a/frontend/desktop/src/pages/callback.tsx
+++ b/frontend/desktop/src/pages/callback.tsx
@@ -140,12 +140,12 @@ export default function Callback() {
                   const initResult = await autoInitRegionToken();
 
                   if (initResult?.data) {
+                    await sessionConfig(initResult.data);
                     gtmLoginSuccess({
                       user_type: 'new',
                       method: 'oauth2',
                       oauth2Provider: provider
                     });
-                    await sessionConfig(initResult.data);
                     const { setInitGuide } = useGuideModalStore.getState();
                     setInitGuide(true);
                     await handleLoginRedirect();
@@ -161,14 +161,14 @@ export default function Callback() {
                 }
                 return;
               }
-              gtmLoginSuccess({
-                user_type: 'existing',
-                method: 'oauth2',
-                oauth2Provider: provider
-              });
               const regionTokenRes = await getRegionToken();
               if (regionTokenRes?.data) {
                 await sessionConfig(regionTokenRes.data);
+                gtmLoginSuccess({
+                  user_type: 'existing',
+                  method: 'oauth2',
+                  oauth2Provider: provider
+                });
                 await handleLoginRedirect();
               }
             } else {

--- a/frontend/desktop/src/types/session.ts
+++ b/frontend/desktop/src/types/session.ts
@@ -12,6 +12,8 @@ export type UserInfo = {
   readonly realName?: string;
   readonly enterpriseRealName?: string;
   readonly k8s_username: string;
+  readonly username?: string;
+  readonly email?: string;
   readonly name: string;
   readonly avatar: string;
   readonly nsid: string;

--- a/frontend/desktop/src/utils/sessionConfig.ts
+++ b/frontend/desktop/src/utils/sessionConfig.ts
@@ -5,6 +5,12 @@ import useSessionStore from '@/stores/session';
 import { SemData } from '@/types/sem';
 import { AdClickData } from '@/types/adClick';
 
+const cleanTraitValue = (value?: string | null) => {
+  if (value === undefined || value === null) return '';
+  const normalized = String(value).trim();
+  return normalized === 'undefined' || normalized === 'null' ? '' : normalized;
+};
+
 export const sessionConfig = async ({
   token,
   kubeconfig,
@@ -18,6 +24,10 @@ export const sessionConfig = async ({
   store.setToken(token); // Sets region token for API requests
   const payload = jwtDecode<AccessTokenPayload>(token);
   const [infoData, planInfo] = await Promise.all([UserInfo(), getPlanInfo(payload.workspaceId)]);
+  const primaryEmail = cleanTraitValue(
+    infoData.data?.info.oauthProvider?.find((provider) => provider.providerType === 'EMAIL')
+      ?.providerId
+  );
 
   store.setSession({
     token: appToken,
@@ -27,6 +37,8 @@ export const sessionConfig = async ({
       realName: infoData.data?.info.realName || undefined,
       enterpriseRealName: infoData.data?.info.enterpriseRealName || undefined,
       k8s_username: payload.userCrName,
+      username: cleanTraitValue(infoData.data?.info.nickname),
+      email: primaryEmail,
       name: infoData.data?.info.nickname || '',
       avatar: infoData.data?.info.avatarUri || '',
       nsid: payload.workspaceId,


### PR DESCRIPTION
This commit enhances the user session initialization process and corrects the timing of analytics events.

- Extracts and stores the user's email from the OAuth provider's response.
- Adds `username` and `email` fields to the session for better user identification and tracking.
- Introduces a `cleanTraitValue` utility to sanitize user attributes before storing them.
- Reorders the `sessionConfig` and `gtmLoginSuccess` calls to ensure the session is fully configured before analytics events are fired. This prevents potential data inconsistencies in GTM.
